### PR TITLE
linter formatter（Ruff）を導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env.dev
 .env.prod
 .DS_Store
+.vscode
 node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "github.copilot.chat.reviewSelection.enabled": false
-}

--- a/backend/docs/実装ガイド.md
+++ b/backend/docs/実装ガイド.md
@@ -25,7 +25,7 @@
   ```
 
 - VScode を使用している場合
-  - プロジェクトルートフォルダ配下の.vscode/settings ファイルに下記設定を追加することで、保存時(Ctrl+S または cmd+s)にコード整形させることが可能
+  - プロジェクトルートフォルダ配下の.vscode/settings.json ファイルに下記設定を追加することで、保存時(Ctrl+S または cmd+s)にコード整形させることが可能
     ```json
     "[python]": {
     "editor.formatOnSave": true,

--- a/backend/docs/実装ガイド.md
+++ b/backend/docs/実装ガイド.md
@@ -1,0 +1,38 @@
+# バックエンド実装ガイド
+
+## リンタ・フォーマッタについて
+
+- リンタ、フォーマッタ共に、Ruff を使用する
+
+  - 公式ドキュメント： https://docs.astral.sh/ruff/
+  - 設定可能なオプション一覧： https://docs.astral.sh/ruff/settings/
+
+- ruff check（リンターチェック実行）
+
+  ```
+  ruff check                  # Lint files in the current directory.
+  ruff check --fix            # Lint files in the current directory and fix any fixable errors.
+  ruff check --watch          # Lint files in the current directory and re-lint on change.
+  ruff check path/to/code/    # Lint files in `path/to/code`.
+  ```
+
+- ruff format（フォーマッタ実行）
+
+  ```
+  ruff format                   # Format all files in the current directory.
+  ruff format path/to/code/     # Format all files in `path/to/code` (and any subdirectories).
+  ruff format path/to/file.py   # Format a single file.
+  ```
+
+- VScode を使用している場合
+  - プロジェクトルートフォルダ配下の.vscode/settings ファイルに下記設定を追加することで、保存時(Ctrl+S または cmd+s)にコード整形させることが可能
+    ```json
+    "[python]": {
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.organizeImports": "explicit"
+    },
+    "editor.defaultFormatter": "charliermarsh.ruff"
+    }
+    ```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,50 @@
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    ".venv",
+    "alembic"
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.11
+target-version = "py311"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`) codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed. example) named by 「_test」 variable -> no warning
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 passlib
 PyJWT
 alembic
+ruff


### PR DESCRIPTION
掲題の対応を実施しました。
お手隙の際にご確認いただけますと幸いです。

dockerで動作確認する場合：
$ docker exec -it {{ バックエンドのコンテナ名 }} pip install -r requirements.txt
$ docker exec -it {{ バックエンドのコンテナ名 }} python -m ruff check app/backend
で実行可能です。